### PR TITLE
Support multiple controllers in the module

### DIFF
--- a/controller/outputs.tf
+++ b/controller/outputs.tf
@@ -1,7 +1,7 @@
-output "private-ip" {
-  value = "${aws_instance.aviatrixcontroller.private_ip}"
+output "private-ips" {
+  value = "${aws_instance.aviatrixcontroller.*.private_ip}"
 }
 
-output "public-ip" {
-  value = "${aws_instance.aviatrixcontroller.public_ip}"
+output "public-ips" {
+  value = "${aws_instance.aviatrixcontroller.*.public_ip}"
 }

--- a/controller/vars.tf
+++ b/controller/vars.tf
@@ -1,3 +1,7 @@
+variable "num_controllers" {
+  default = 1
+}
+
 variable "region" {}
 
 variable "vpc" {}


### PR DESCRIPTION
Not sure if this is necessary or even supported, but these changes allow for spinning up multiple controllers using the same module.

Unfortunately, doing so with these changes force both instances to be in the same subnet, which usually implies the same AZ.  However, fixing that requires making changes that are not backwards compatible.

The only non-backwards compatible changes is the change to the output name to pluralize the name and to make the outputs lists instead of single elements.