### PR TITLE
Support passing list of multiple CIDRs for controller ingress

### DIFF
--- a/controller/security_group.tf
+++ b/controller/security_group.tf
@@ -14,7 +14,7 @@ resource "aws_security_group_rule" "ingress_rule" {
   from_port         = 443
   to_port           = 443
   protocol          = "tcp"
-  cidr_blocks       = ["${var.incoming_ssl_cidr}"]
+  cidr_blocks       = "${var.incoming_ssl_cidr}"
   security_group_id = "${aws_security_group.AviatrixSecurityGroup.id}"
 }
 

--- a/controller/vars.tf
+++ b/controller/vars.tf
@@ -22,7 +22,7 @@ variable "root_volume_type" {
 }
 
 variable "incoming_ssl_cidr" {
-  default = "0.0.0.0/0"
+  default = ["0.0.0.0/0"]
 }
 
 variable "instance_type" {


### PR DESCRIPTION
Changes incoming_ssl_cidr from string to list to allow passing of multiple CIDRs
```
module "aviatrixcontroller" {
  source = "github.com/AviatrixSystems/terraform-modules.git/controller"
  region  = "<<insert aws region here, ie.: us-east-1>>"
  vpc = "<<insert VPC here> ie. vpc-xxxxxx>"
  subnet = "<<insert public subnet id ie.: subnet-9x3237xx>>"
  keypair = "<<insert keypair name ie.: keypairname>>"
  ec2role = "<<insert role for aviatrix-role-ec2>> OR if you are using the iam_role simply use this: ${module.iam_roles.aviatrix-role-ec2}"
  incoming_ssl_cidr = ["192.168.0.5/32","192.168.0.100/32"]
}
```