### PR TITLE
Terraform Aviatrix App Policy SQS Permission Add

### DIFF
--- a/iam_roles/iam_roles.tf
+++ b/iam_roles/iam_roles.tf
@@ -246,7 +246,8 @@ resource "aws_iam_policy" "aviatrix-app-policy" {
               "sqs:ReceiveMessage",
               "sqs:RemovePermission",
               "sqs:SendMessage",
-              "sqs:SetQueueAttributes"
+              "sqs:SetQueueAttributes",
+              "sqs:TagQueue"
           ],
           "Resource": "*"
       },


### PR DESCRIPTION
In [Section 1.2 ](https://aviatrix-systems-inc-docs.readthedocs-hosted.com/HowTos/HowTo_IAM_role.html?highlight=iam#create-aviatrix-app-policy) of the tutorial for setting IAM roles for an Aviatrix deployment, we are instructed to use a provided [IAM role](https://s3-us-west-2.amazonaws.com/aviatrix-download/I). This role differs from the current Terraform module, which doesn't include `"sqs:TagQueue"`. Currently, Aviatrix VPN won't work without this permission set.