### PR TITLE
Add option for name prefix to avoid collisions

### DIFF
--- a/controller/controller.tf
+++ b/controller/controller.tf
@@ -16,13 +16,13 @@ resource "aws_network_interface" "eni-controller" {
   security_groups = ["${aws_security_group.AviatrixSecurityGroup.id}"]
 
   tags {
-    Name      = "${format("%s : %d", "Aviatrix Controller interface", count.index)}"
+    Name      = "${format("%s%s : %d", local.name_prefix, "Aviatrix Controller interface", count.index)}"
     Createdby = "Terraform+Aviatrix"
   }
 }
 
 resource "aws_iam_instance_profile" "aviatrix-role-ec2_profile" {
-  name = "aviatrix-role-ec2_profile"
+  name = "${local.name_prefix}aviatrix-role-ec2_profile"
   role = "${var.ec2role}"
 }
 
@@ -44,7 +44,7 @@ resource "aws_instance" "aviatrixcontroller" {
   }
 
   tags {
-    Name      = "${format("%s : %d", "AviatrixController", count.index)}"
+    Name      = "${format("%s%s : %d", local.name_prefix, "AviatrixController", count.index)}"
     Createdby = "Terraform+Aviatrix"
   }
 }

--- a/controller/security_group.tf
+++ b/controller/security_group.tf
@@ -1,10 +1,10 @@
 resource "aws_security_group" "AviatrixSecurityGroup" {
-  name        = "AviatrixSecurityGroup"
+  name        = "${local.name_prefix}AviatrixSecurityGroup"
   description = "Aviatrix - Controller Security Group"
   vpc_id      = "${var.vpc}"
 
   tags {
-    Name      = "AviatrixSecurityGroup"
+    Name      = "${local.name_prefix}AviatrixSecurityGroup"
     Createdby = "Terraform+Aviatrix"
   }
 }

--- a/controller/vars.tf
+++ b/controller/vars.tf
@@ -26,6 +26,7 @@ variable "root_volume_type" {
 }
 
 variable "incoming_ssl_cidr" {
+  type = "list"
   default = ["0.0.0.0/0"]
 }
 
@@ -38,6 +39,7 @@ variable "name_prefix" {
 }
 
 variable "images" {
+  type = "map"
   default = {
     us-east-1      = "ami-690c467e"
     us-east-2      = "ami-811248e4"

--- a/controller/vars.tf
+++ b/controller/vars.tf
@@ -33,6 +33,10 @@ variable "instance_type" {
   default = "t2.large"
 }
 
+variable "name_prefix" {
+  default = ""
+}
+
 variable "images" {
   default = {
     us-east-1      = "ami-690c467e"
@@ -51,3 +55,8 @@ variable "images" {
     sa-east-1      = "ami-bcf66bd0"
   }
 }
+
+locals {
+  name_prefix = ${var.name_prefix != "" ? "${var.name_prefix}-" : ""}
+}
+

--- a/controller/vars.tf
+++ b/controller/vars.tf
@@ -57,6 +57,6 @@ variable "images" {
 }
 
 locals {
-  name_prefix = ${var.name_prefix != "" ? "${var.name_prefix}-" : ""}
+  name_prefix = "${var.name_prefix != "" ? "${var.name_prefix}-" : ""}"
 }
 

--- a/iam_roles/iam_roles.tf
+++ b/iam_roles/iam_roles.tf
@@ -14,7 +14,7 @@ provider "aws" {
 }
 
 locals {
-  name_prefix = ${var.name_prefix != "" ? "${var.name_prefix}-" : ""}
+  name_prefix = "${var.name_prefix != "" ? "${var.name_prefix}-" : ""}"
 }
 
 # Roles

--- a/iam_roles/iam_roles.tf
+++ b/iam_roles/iam_roles.tf
@@ -1,5 +1,8 @@
 variable "region" {}
 
+variable "name_prefix" {
+  default = ""
+}
 variable "master-account-id" {
   default = "false"
 }
@@ -10,10 +13,14 @@ provider "aws" {
   region     = "${var.region}"
 }
 
+locals {
+  name_prefix = ${var.name_prefix != "" ? "${var.name_prefix}-" : ""}
+}
+
 # Roles
 
 resource "aws_iam_role" "aviatrix-role-ec2" {
-  name = "aviatrix-role-ec2"
+  name = "${local.name_prefix}aviatrix-role-ec2"
   description = "Aviatrix EC2 - Created by Terraform+Aviatrix"
   path = "/"
   assume_role_policy = <<EOF
@@ -35,7 +42,7 @@ EOF
 }
 
 resource "aws_iam_role" "aviatrix-role-app" {
-  name = "aviatrix-role-app"
+  name = "${local.name_prefix}aviatrix-role-app"
   description = "Aviatrix APP - Created by Terraform+Aviatrix"
   path = "/"
   assume_role_policy = <<EOF
@@ -57,7 +64,7 @@ EOF
 }
 
 resource "aws_iam_policy" "aviatrix-assume-role-policy" {
-  name        = "aviatrix-assume-role-policy"
+  name        = "${local.name_prefix}aviatrix-assume-role-policy"
   path        = "/"
   description = "Policy for creating aviatrix-assume-role-policy"
 
@@ -78,7 +85,7 @@ EOF
 }
 
 resource "aws_iam_policy" "aviatrix-app-policy" {
-  name        = "aviatrix-app-policy"
+  name        = "${local.name_prefix}aviatrix-app-policy"
   path        = "/"
   description = "Policy for creating aviatrix-app-policy"
 


### PR DESCRIPTION
This PR allows for someone to create multiple aviatrix controllers across different regions in the same account. Since IAM role names are global and need to be unique, the current implementation does not allow for the creation of more than one controller. This PR adds the ability to namespace all named modules in order to avoid naming collisions and to have a consistent naming convention throughout all modules.