### PR TITLE
Expose created IAM role ARNs through outputs.

### DIFF
--- a/iam_roles/iam_roles.tf
+++ b/iam_roles/iam_roles.tf
@@ -281,6 +281,14 @@ output "aviatrix-role-ec2" {
     value = "${aws_iam_role.aviatrix-role-ec2.id}"
 }
 
+output "aviatrix-role-ec2-arn" {
+    value = "${aws_iam_role.aviatrix-role-ec2.arn}"
+}
+
 output "aviatrix-role-app" {
     value = "${aws_iam_role.aviatrix-role-app.id}"
+}
+
+output "aviatrix-role-app-arn" {
+    value = "${aws_iam_role.aviatrix-role-app.arn}"
 }


### PR DESCRIPTION
The [Aviatrix terraform provider](https://github.com/AviatrixSystems/terraform-provider-aviatrix) needs these values to init an AWS controller. Exposing them to tie the terraform together with the provider..