### PR TITLE
reformat controller name.

### DIFF
--- a/aviatrix-controller-build/main.tf
+++ b/aviatrix-controller-build/main.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "aviatrixcontroller" {
   }
 
   tags {
-    Name      = "${format("%s%s : %d", local.name_prefix, "AviatrixController", count.index)}"
+    Name      = "${format("%s%s-%d", local.name_prefix, "AviatrixController", count.index)}"
     Createdby = "Terraform+Aviatrix"
   }
 }


### PR DESCRIPTION
Previous format will cause an issue when trying to enable HA using the cloudformation template. Remove spaces and replaced `:` with `-`

Per Cloudformation template: 
> Enter the existing controller instance name. It should contain only letters, numbers, hyphens, or underscores. No spaces allowed