### PR TITLE
(8400): Updated controller build module to change root_volume_size default value

### DIFF
--- a/aviatrix-controller-build/README.md
+++ b/aviatrix-controller-build/README.md
@@ -49,7 +49,7 @@ module "aviatrixcontroller" {
 
 - **root_volume_size**
   
-  Default value is 16, as suggested by Aviatrix
+  Default value is 20, as suggested by Aviatrix
 
 - **root_volume_type**
   

--- a/aviatrix-controller-build/main.tf
+++ b/aviatrix-controller-build/main.tf
@@ -22,11 +22,12 @@ resource "aws_network_interface" "eni-controller" {
 }
 
 resource "aws_instance" "aviatrixcontroller" {
-  count                = "${var.num_controllers}"
-  ami                  = "${local.ami_id}"
-  instance_type        = "${var.instance_type}"
-  key_name             = "${var.keypair}"
-  iam_instance_profile = "${var.ec2role}"
+  count                   = "${var.num_controllers}"
+  ami                     = "${local.ami_id}"
+  instance_type           = "${var.instance_type}"
+  key_name                = "${var.keypair}"
+  iam_instance_profile    = "${var.ec2role}"
+  disable_api_termination = true
 
   network_interface {
     network_interface_id = "${element(aws_network_interface.eni-controller.*.id, count.index)}"

--- a/aviatrix-controller-build/variables.tf
+++ b/aviatrix-controller-build/variables.tf
@@ -16,7 +16,7 @@ variable "ec2role" {}
 
 # This is the default root volume size as suggested by Aviatrix
 variable "root_volume_size" {
-  default = 16
+  default = 20
 }
 
 variable "root_volume_type" {


### PR DESCRIPTION
Changed default value of root_volume_size from 16 to 20;
Also set disable_api_termination to true.