### PR TITLE
(0013296) Add protection to controller build module to prevent controller replacement if AMI already exists

### DIFF
--- a/aviatrix-controller-build/main.tf
+++ b/aviatrix-controller-build/main.tf
@@ -41,4 +41,10 @@ resource "aws_instance" "aviatrixcontroller" {
     Name      = format("%s%s-%d", local.name_prefix, "AviatrixController", count.index)
     Createdby = "Terraform+Aviatrix"
   }
+
+  lifecycle {
+    ignore_changes = [
+      "ami"
+    ]
+  }
 }


### PR DESCRIPTION
Currently, Aviatrix controller module dynamically uses latest AMI to launch controller. "terraform apply" may force to replace controller if it was launched using previous AMI.