### PR TITLE
updating default instance type in readme

### DIFF
--- a/aviatrix-controller-build/README.md
+++ b/aviatrix-controller-build/README.md
@@ -63,7 +63,7 @@ module "aviatrixcontroller" {
 
 - **instance_type**
 
-  The instance size for the Aviatrix controller instance. Default value is "t2.large".
+  The instance size for the Aviatrix controller instance. Default value is "t3.large".
 
 - **name_prefix**
 


### PR DESCRIPTION
default instance type is t3.large per variables.tf and not t2.large any longer.