### PR TITLE
I dont think quotes are needed any longer

### DIFF
--- a/aviatrix-controller-build/main.tf
+++ b/aviatrix-controller-build/main.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "aviatrixcontroller" {
 
   lifecycle {
     ignore_changes = [
-      "ami"
+      ami
     ]
   }
 }


### PR DESCRIPTION
I got this while running this module on Terraform Terraform v0.12.19 --
---

Warning: Quoted references are deprecated

  on .terraform/modules/aviatrixcontroller/aviatrix-controller-build/main.tf line 47, in resource "aws_instance" "aviatrixcontroller":
  47:       "ami"

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.

---