### PR TITLE
change Name tag on controller to remove spaces

### DIFF
--- a/aviatrix-controller-build/main.tf
+++ b/aviatrix-controller-build/main.tf
@@ -38,7 +38,7 @@ resource aws_instance aviatrixcontroller {
   }
 
   tags = merge(local.common_tags, {
-    Name = "${local.name_prefix} AviatrixController ${count.index}"
+    Name = "${local.name_prefix}AviatrixController-${count.index}"
   })
 
   lifecycle {

--- a/aviatrix-controller-build/outputs.tf
+++ b/aviatrix-controller-build/outputs.tf
@@ -23,6 +23,6 @@ output security_group_id {
   description = "Security group id used by Aviatrix controller"
 }
 
-output "name_prefix" {
+output name_prefix {
   value = var.name_prefix
 }

--- a/aviatrix-controller-build/variables.tf
+++ b/aviatrix-controller-build/variables.tf
@@ -83,7 +83,7 @@ locals {
   name_prefix     = var.name_prefix != "" ? "${var.name_prefix}-" : ""
   images_byol     = jsondecode(data.http.avx_iam_id.body).BYOL
   images_platinum = jsondecode(data.http.avx_iam_id.body).MeteredPlatinum
-  ami_id          = "${(var.type == "BYOL" || var.type == "byol")? local.images_byol[data.aws_region.current.name] : local.images_platinum[data.aws_region.current.name]}"
+  ami_id          = var.type == "BYOL" || var.type == "byol"? local.images_byol[data.aws_region.current.name] : local.images_platinum[data.aws_region.current.name]
   common_tags = merge(
     var.tags, {
       module    = "aviatrix-controller-build"


### PR DESCRIPTION
This is addressing issue https://github.com/AviatrixSystems/terraform-modules/issues/68 what is changing `Name` tag to string without whitespaces.

Terraform plan after change and without using name_prefix (`tags` > `Name` value):
```
# aws_instance.aviatrixcontroller[0] will be created
  + resource "aws_instance" "aviatrixcontroller" {
      + ami                          = "ami-0a81f891b1aac5672"
     ..................
      + subnet_id                    = (known after apply)
      + tags                         = {
          + "Createdby" = "Terraform+Aviatrix"
          + "Name"      = "AviatrixController-0"
          + "module"    = "aviatrix-controller-build"
        }
      + tenancy                      = (known after apply)
     ..................
     }
```

Terraform plan after change and with using name_prefix (`tags` > `Name` value):
```
# aws_instance.aviatrixcontroller[0] will be created
  + resource "aws_instance" "aviatrixcontroller" {
      + ami                          = "ami-0a81f891b1aac5672"
        ..................
      + subnet_id                    = (known after apply)
      + tags                         = {
          + "Createdby" = "Terraform+Aviatrix"
          + "Name"      = "test-AviatrixController-0"
          + "module"    = "aviatrix-controller-build"
        }
      + tenancy                      = (known after apply)
     ..................
     }
```


It has also some few minot optimisation for code clearance.

This was tested on terraform 0.12.
