### PR TITLE
Add IAM role ARN's to outputs

### DIFF
--- a/aviatrix-controller-iam-roles/outputs.tf
+++ b/aviatrix-controller-iam-roles/outputs.tf
@@ -1,19 +1,43 @@
-
-output "aws-account" {
+output aws-account {
   value       = data.aws_caller_identity.current.account_id
   description = "AWS account Id"
 }
 
-output "aviatrix-role-ec2-name" {
+output aviatrix-role-ec2-name {
   value       = aws_iam_role.aviatrix-role-ec2.name
-  description = "Aviatrix role for EC2"
+  description = "Aviatrix role name for EC2"
 }
 
-output "aviatrix-role-app-name" {
+output aviatrix-role-ec2-arn {
+  value       = aws_iam_role.aviatrix-role-ec2.arn
+  description = "Aviatrix role ARN for EC2"
+}
+
+output aviatrix-role-app-name {
   value       = aws_iam_role.aviatrix-role-app.name
-  description = "Aviatrix role for application"
+  description = "Aviatrix role name for application"
 }
 
-output "name_prefix" {
+output aviatrix-role-app-arn {
+  value       = aws_iam_role.aviatrix-role-app.arn
+  description = "Aviatrix role ARN for application"
+}
+
+output aviatrix-assume-role-policy-arn {
+  value       = aws_iam_policy.aviatrix-assume-role-policy.arn
+  description = "Aviatrix assume role policy ARN"
+}
+
+output aviatrix-app-policy-arn {
+  value       = aws_iam_policy.aviatrix-app-policy.arn
+  description = "Aviatrix policy ARN for application"
+}
+
+output aviatrix-role-ec2_profile-arn {
+  value       = aws_iam_instance_profile.aviatrix-role-ec2_profile.arn
+  description = "Aviatrix role EC2 profile ARN for application"
+}
+
+output name_prefix {
   value = var.name_prefix
 }


### PR DESCRIPTION
This is addressing enhance request https://github.com/AviatrixSystems/terraform-modules/issues/56


Terraform apply outputs:
```
Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:
aviatrix-app-policy-arn = arn:aws:iam::3063432404:policy/aviatrix-app-policy
aviatrix-assume-role-policy-arn = arn:aws:iam::3063432404:policy/aviatrix-assume-role-policy
aviatrix-role-app-arn = arn:aws:iam::3063432404:role/aviatrix-role-app
aviatrix-role-app-name = aviatrix-role-app
aviatrix-role-ec2-arn = arn:aws:iam::3063432404:role/aviatrix-role-ec2
aviatrix-role-ec2-name = aviatrix-role-ec2
aviatrix-role-ec2_profile-arn = arn:aws:iam::3063432404:instance-profile/aviatrix-role-ec2
aws-account = 3063432404
name_prefix =
```

This also contains some minor code clearance change (like quotation).

Everything was tested on terraform 0.12