### PR TITLE
Replace null_resource delay to fix cross-platform compatibility

### DIFF
--- a/aviatrix-controller-initialize/main.tf
+++ b/aviatrix-controller-initialize/main.tf
@@ -81,16 +81,15 @@ resource aws_lambda_function lambda {
   depends_on = [aws_iam_role_policy_attachment.attach-policy, aws_security_group.AviatrixLambdaSecurityGroup]
 }
 
-resource null_resource delay {
-  provisioner local-exec {
-    command = "sleep 90"
-  }
+resource time_sleep wait_90_seconds {
+  create_duration = "90s"
+
   depends_on = [aws_lambda_function.lambda]
 }
 
 data aws_lambda_invocation example {
   function_name = aws_lambda_function.lambda.function_name
-  depends_on    = [null_resource.delay]
+  depends_on    = [time_sleep.wait_90_seconds]
   input         = <<JSON
 { "ResourceProperties":
 {


### PR DESCRIPTION
This prevents cross-platform compatibility and destroy-time issues with using the local-exec provisioner.

Source: https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep