### PR TITLE
Add required_providers to modules

### DIFF
--- a/aviatrix-controller-build/required_providers.tf
+++ b/aviatrix-controller-build/required_providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/aviatrix-controller-iam-roles/required_providers.tf
+++ b/aviatrix-controller-iam-roles/required_providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}

--- a/aviatrix-controller-initialize/required_providers.tf
+++ b/aviatrix-controller-initialize/required_providers.tf
@@ -1,0 +1,7 @@
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}


### PR DESCRIPTION
Because we load the aviatrix modules using an alias:

```
module "iam_roles_on_networks" {
  # tflint-ignore: terraform_module_pinned_source
  source                         = "git::https://github.com/AviatrixSystems/terraform-modules.git//aviatrix-controller-iam-roles?ref=terraform_0.12"
  external-controller-account-id = var.aws_account_ids_shared

  providers = {
    aws = aws.networks
  }
}
```

We get the following warning with our TF plans using TFE + TF v1.0.0:

```
│ Warning: Provider aws is undefined
│
│   on .terraform/modules/skeleton/iam.tf line 15, in module "iam_roles_on_networks":
│   15:     aws = aws.networks
│
│ Module module.skeleton.module.iam_roles_on_networks does not declare a provider named aws.
│ If you wish to specify a provider configuration for the module, add an entry for aws in the required_providers
│ block within the module.
```

Solution is to add `required_providers` as per TF documentation: https://www.terraform.io/docs/language/providers/configuration.html