### PR TITLE
Update variables.tf

### DIFF
--- a/aviatrix-controller-build/variables.tf
+++ b/aviatrix-controller-build/variables.tf
@@ -49,7 +49,7 @@ variable incoming_ssl_cidr {
 variable root_volume_size {
   type        = number
   description = "Root volume disk size for controller"
-  default     = 32
+  default     = 64
 }
 
 variable root_volume_type {


### PR DESCRIPTION
the current default value (32GB) produce the following error message:

Error: creating EC2 Instance: InvalidBlockDeviceMapping: Volume of size 32GB is smaller than  snapshot 'snap-07e2b798c602021be', expect size >= 64GB
│       status code: 400, request id: f37c4e48-3f90-4956-b60b-7381f817fbf9
│
│   with module.aviatrix-controller-build.aws_instance.aviatrixcontroller[0],
│   on .terraform\modules\aviatrix-controller-build\aviatrix-controller-build\main.tf line 25, in resource "aws_instance" "aviatrixcontroller":
│   25: resource aws_instance aviatrixcontroller {

After locally applying the above small change (in the module var file), I got no more error message 